### PR TITLE
Show in the toolbar how underline looks

### DIFF
--- a/www/styles/custom-attributes.css
+++ b/www/styles/custom-attributes.css
@@ -61,3 +61,31 @@
 .ql-snow .ql-picker.ql-underline-style {
     width: 120px;
 }
+
+.ql-picker-label[data-value="style-double"]::before{
+  text-decoration: underline;
+  border-bottom: 1px double;
+}
+
+.ql-picker-label[data-value="style-thick"]::before{
+  text-decoration: none;
+  border-bottom: 3px solid;
+}
+
+.ql-picker-label[data-value="style-single"]::before{
+  text-decoration: underline;
+}
+
+.ql-picker-item[data-value="style-double"]::before{
+  text-decoration: underline;
+  border-bottom: 1px double;
+}
+
+.ql-picker-item[data-value="style-thick"]::before{
+  text-decoration: none;
+  border-bottom: 3px solid;
+}
+
+.ql-picker-item[data-value="style-single"]::before{
+  text-decoration: underline;
+}


### PR DESCRIPTION
Hi @andresinaka,

I modified the css file and I obtain the following change in the underline selection:

![item](https://user-images.githubusercontent.com/15159185/33806843-290baf4a-ddce-11e7-876d-5072fcc22908.PNG)

and in the toolbar:

![label](https://user-images.githubusercontent.com/15159185/33806850-403b3cc6-ddce-11e7-8e86-f13898ecb1e0.PNG)

