### PR TITLE
Remove inferable type. Use NSRange initializer

### DIFF
--- a/src/SwiftTranslator.js
+++ b/src/SwiftTranslator.js
@@ -34,7 +34,7 @@ class SwiftTranslator {
 
       if(attributes.length > 0) {
         attributedString = attributedString + '\n' + this.addAttributes(
-          `NSMakeRange(${start}, ${length})`,
+          `NSRange(location: ${start}, length: ${length})`,
           attributeName,
           attributes
         );

--- a/src/swift-attributes/BackgroundColor.js
+++ b/src/swift-attributes/BackgroundColor.js
@@ -7,7 +7,7 @@ class BackgroundColor extends Attribute {
       let [red, green, blue] = this.hexToRgb(attributes["background"]);
 
       let color = `UIColor(red: ${red}/255, green: ${green}/255, blue: ${blue}/255, alpha: 1.0)`;
-      return `NSAttributedStringKey.backgroundColor: ${color}`;
+      return `.backgroundColor: ${color}`;
     }
   }
 }

--- a/src/swift-attributes/FontAttribute.js
+++ b/src/swift-attributes/FontAttribute.js
@@ -18,7 +18,7 @@ class FontAttribute extends Attribute {
       let fontSize = attributes["size"].replace("px", "");
 
       let font = `UIFont(name: "${fontName}", size: ${fontSize})!`;
-      return `NSAttributedStringKey.font: ${font}`;
+      return `.font: ${font}`;
     }
   }
 

--- a/src/swift-attributes/FontColor.js
+++ b/src/swift-attributes/FontColor.js
@@ -7,7 +7,7 @@ class FontColor extends Attribute {
       let [red, green, blue] = this.hexToRgb(attributes["color"]);
 
       let color = `UIColor(red: ${red}/255, green: ${green}/255, blue: ${blue}/255, alpha: 1.0)`;
-      return `NSAttributedStringKey.foregroundColor: ${color}`;
+      return `.foregroundColor: ${color}`;
     }
   }
 }

--- a/src/swift-attributes/ParagraphAttribute.js
+++ b/src/swift-attributes/ParagraphAttribute.js
@@ -22,7 +22,7 @@ class ParagraphAttribute extends Attribute {
   parse() {
     let attributes = this.attributes;
     if (attributes && "align" in attributes) {      
-      return `NSAttributedStringKey.paragraphStyle: ${this.paragraphName}`;
+      return `.paragraphStyle: ${this.paragraphName}`;
     }
   }
 

--- a/src/swift-attributes/UnderlineAttribute.js
+++ b/src/swift-attributes/UnderlineAttribute.js
@@ -9,7 +9,7 @@ class UnderlineAttribute extends Attribute {
 
       if(!underline) { return null }
 
-      return `NSAttributedStringKey.underlineStyle: NSUnderlineStyle.${underline}.rawValue`;
+      return `.underlineStyle: NSUnderlineStyle.${underline}.rawValue`;
     }
   }
 

--- a/tests/swift-attributes/BackgroundColorTest.js
+++ b/tests/swift-attributes/BackgroundColorTest.js
@@ -1,12 +1,12 @@
 import test from 'ava';
 import BackgroundColor from '../../src/swift-attributes/BackgroundColor';
 
-test("BacgroundColor", t => {
+test("BackgroundColor", t => {
   let item = {"background": "#ffffff"};
   let backgroundColor = new BackgroundColor(item).parse()
 
   t.deepEqual(
-    "NSAttributedStringKey.backgroundColor: UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 1.0)",
+    ".backgroundColor: UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 1.0)",
     backgroundColor
   );
 });

--- a/tests/swift-attributes/FontAttributeTest.js
+++ b/tests/swift-attributes/FontAttributeTest.js
@@ -6,7 +6,7 @@ test('Only font parameter', t => {
   let fontAttribute = new FontAttribute(item).parse();
 
   t.deepEqual(
-    'NSAttributedStringKey.font: UIFont(name: "HelveticaNeue", size: 13)!',
+    '.font: UIFont(name: "HelveticaNeue", size: 13)!',
     fontAttribute
   );
 });
@@ -16,7 +16,7 @@ test('Only size parameter', t => {
   let fontAttribute = new FontAttribute(item).parse();
 
   t.deepEqual(
-    'NSAttributedStringKey.font: UIFont(name: "HelveticaNeue", size: 25)!',
+    '.font: UIFont(name: "HelveticaNeue", size: 25)!',
     fontAttribute
   );
 });
@@ -26,7 +26,7 @@ test('name and size parameters', t => {
   let fontAttribute = new FontAttribute(item).parse();
 
   t.deepEqual(
-    'NSAttributedStringKey.font: UIFont(name: "HelveticaNeue-Bold", size: 30)!',
+    '.font: UIFont(name: "HelveticaNeue-Bold", size: 30)!',
     fontAttribute
   );
 });

--- a/tests/swift-attributes/FontColorTest.js
+++ b/tests/swift-attributes/FontColorTest.js
@@ -6,7 +6,7 @@ test("Font color", t => {
   let fontColor = new FontColor(item).parse()
 
   t.deepEqual(
-    "NSAttributedStringKey.foregroundColor: UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 1.0)",
+    ".foregroundColor: UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 1.0)",
     fontColor
   );
 });

--- a/tests/swift-attributes/ParagraphAttributeTest.js
+++ b/tests/swift-attributes/ParagraphAttributeTest.js
@@ -11,7 +11,7 @@ test("Paragraph", t => {
   );
 
   t.deepEqual(
-    "NSAttributedStringKey.paragraphStyle: paragraphStyle1",
+    ".paragraphStyle: paragraphStyle1",
     paragraphAttribute.parse()
   );
 });

--- a/tests/swift-attributes/UnderlineAttributeTest.js
+++ b/tests/swift-attributes/UnderlineAttributeTest.js
@@ -6,7 +6,7 @@ test("Underline", t => {
   let underline = new UnderlineAttribute(item).parse()
 
   t.deepEqual(
-    "NSAttributedStringKey.underlineStyle: NSUnderlineStyle.styleSingle.rawValue",
+    ".underlineStyle: NSUnderlineStyle.styleSingle.rawValue",
     underline
   );
 });


### PR DESCRIPTION
- Remove inferable type of `NSAttributedStringKey`
- Use preferred Swift `NSRange` initializer