### PR TITLE
Updated attributeName at SwiftTranslator for Swift 4.2 notation

### DIFF
--- a/src/SwiftTranslator.js
+++ b/src/SwiftTranslator.js
@@ -72,7 +72,7 @@ class SwiftTranslator {
     if(attributes.length == 0) { return ""; }
 
     let cocoaAttributes =  
-    `let ${attributeName}: [NSAttributedStringKey : Any] = [\n` +
+    `let ${attributeName}: [NSAttributedString.Key : Any] = [\n` +
     `   ${attributes.join(",\n   ")}\n` +
     `]\n` +
     `attributedString.addAttributes(${attributeName}, range: ${range})\n`


### PR DESCRIPTION
* Updated attributeName value from `NSAttributedStringKey` to `NSAttributedString.Key`

## Input:

This is an **attributed** string

## Generated code before change
![Captura de Tela 2020-05-18 às 10 43 54](https://user-images.githubusercontent.com/23082132/82220820-8987a880-98f5-11ea-9165-bf2a80df37bc.png)
Error: 'NSAttributedStringKey' has been renamed to 'NSAttributedString.Key'
## Generated code after change
![Captura de Tela 2020-05-18 às 10 44 04](https://user-images.githubusercontent.com/23082132/82220828-8bea0280-98f5-11ea-9304-219ba9c3164d.png)
